### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1088,6 +1088,11 @@ sourcify <- function(object, indent='') {
         }
 
         return(source)
+      
+    } else if (is.language(object) && ! is.symbol(object)) {
+        source <- sourcify(paste(trimws(format(object)), collapse=' '), indent)
+        
+        return(paste0('as.formula(', source, ')'));      
 
     } else if (is.list(object) || is.environment(object)) {
 


### PR DESCRIPTION
The analysis options may contain formulas that are currently not "sourcified" (an empty string is returned). The additional code carries out this transformation - the formula is first converted into a string and then enclosed with "as.formula()". The second condition in else if (! is.symbol(object)) is required because other parameters (data, vars, group, etc.) are originally defined as symbols too.