### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1089,6 +1089,11 @@ sourcify <- function(object, indent='') {
 
         return(source)
 
+    } else if (inherits(object, 'formula')) {
+        source <- sourcify(paste(trimws(format(object)), collapse=' '), indent)
+        
+        return(paste0('as.formula(', source, ')'));
+
     } else if (is.list(object) || is.environment(object)) {
 
         if (length(object) == 0)


### PR DESCRIPTION
The analysis options may contain formulas that are currently not "sourcified" (an empty string is returned). The additional code carries out this transformation - the formula is first converted into a string and then enclosed with "as.formula()".