### PR TITLE
Select function passes data frame attributes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1120,13 +1120,12 @@ sourcify <- function(object, indent='') {
 #' Create a new data frame with only the selected columns
 #'
 #' Shorthand equivalent to \code{\link{subset}(df, select=columnNames)}, however
-#' it additionally preserves attributes on the columns
+#' it additionally preserves attributes on the columns and the data frame
 #' @param df the data frame
 #' @param columnNames the names of the columns to make up the new data frame
 #' @return the new data frame
 #' @export
 select <- function(df, columnNames) {
-
     out <- list()
     for (i in seq_along(columnNames)) {
         columnName <- unlist(columnNames[i])
@@ -1135,6 +1134,13 @@ select <- function(df, columnNames) {
     }
     data <- data.frame(out)
     colnames(data) <- names(out)
+
+    # Copy attributes to new data frame
+    attributeNamesOld <- names(attributes(df))
+    attributeNamesNew <- names(attributes(data))
+    for (attributeName in attributeNamesOld[! attributeNamesOld %in% attributeNamesNew])
+        attr(data, attributeName) <- attr(df, attributeName)
+
     data
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,33 +1,51 @@
 
-context('utils')
+testthat::context('utils')
 
-test_that('extractRegexMatches() works', {
+testthat::test_that('extractRegexMatches() works', {
     content <- 'fred:jim && bob:will'
     matches <- gregexpr('[A-Za-z][A-Za-z0-9]*:[A-Za-z][A-Za-z0-9]*', content)
-    expect_equal(extractRegexMatches(content, matches), c('fred:jim', 'bob:will'))
+    testthat::expect_equal(extractRegexMatches(content, matches), c('fred:jim', 'bob:will'))
 })
 
-test_that('replaceRegexMatches() works', {
+testthat::test_that('replaceRegexMatches() works', {
     content <- '(fred:jim && bob:will) || fred:glen'
     matches <- gregexpr('[A-Za-z][A-Za-z0-9]*:[A-Za-z][A-Za-z0-9]*', content)
     replaced <- replaceRegexMatches(content, matches, c('pow', 'wow', 'woo'))
-    expect_equal(replaced, '(pow && wow) || woo')
+    testthat::expect_equal(replaced, '(pow && wow) || woo')
 })
 
-test_that('htmlToText() works', {
+testthat::test_that('htmlToText() works', {
     html <- '<h1>bruce</h1>'
     text <- htmlToText(html)
-    expect_equal(text, 'bruce')
+    testthat::expect_equal(text, 'bruce')
 
     html <- '<h1>bruce</h1>fred'
     text <- htmlToText(html)
-    expect_equal(text, 'bruce\n\nfred')
+    testthat::expect_equal(text, 'bruce\n\nfred')
 
     html <- '<p>p1</p><p>p2</p>'
     text <- htmlToText(html)
-    expect_equal(text, 'p1\n\np2')
+    testthat::expect_equal(text, 'p1\n\np2')
 
     html <- '&alpha; = 3'
     text <- htmlToText(html)
-    expect_equal(text, '\u03B1 = 3')
+    testthat::expect_equal(text, '\u03B1 = 3')
+})
+
+testthat::test_that('select() passes attributes', {
+    # GIVEN a data frame
+    df <- data.frame(x=1, y=2)
+    # AND an attribute added to this data frame
+    attributeName <- 'jmv-weights'
+    attributeValue <- 3
+    attr(df, attributeName) <- attributeValue
+
+    # WHEN a certain column is selected
+    dfNew <- jmvcore::select(df, c("y"))
+
+    # THEN the attribute is present in the subset
+    newAttributes <- attributes(dfNew)
+    testthat::expect_true(attributeName %in% names(newAttributes))
+    # AND the value remains the same
+    testthat::expect_equal(newAttributes[[attributeName]], attributeValue)
 })


### PR DESCRIPTION
Previously, only column attributes were preserved when using the custom jmvcore select function. With this commit, attributes that are set on the data frame are also preserved.